### PR TITLE
Included grid resolution in filename

### DIFF
--- a/bsubScripts/ncum_global_osf_input/ncum_global_osf_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_osf_input/ncum_global_osf_input_um2grb2_setup.cfg
@@ -93,10 +93,15 @@ overwriteFiles = True
 ## single digit hour, it will fill 0 as prefix to make it as 2 digit.
 ## same option for utc '*Z*'.
 ## Note : * will not be included in the name of the final out grib2 files.
-## for eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
+## eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
 ## this will produce analysis files as 'um_ana_006hr_20160208_12Z.grib2'
-## for eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
+## eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
 ## produce forecast files as 'fcs_06h_z20160208.grb2'
+## eg3 : ('prg', '*D*', '00z', '*%d%m%y*', '.grb2') will produce grib2 files 
+## as 'prg100z080216.grb2'  
+## eg4 : ('prg', '*D*', '00z', '*%d%m%y*', '_', '*pxp*' '.grb2') will produce grib2 files 
+## as 'prg100z080216_0p17x0p17.grb2' in case of targetGridResolution = None (i.e modelResolution)  
+## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
 anlOutGrib2FilesNameStructure = ('ncum_anal', '_', '*ZZ*', 'z', '*YYYYMMDD*', '.grb2')

--- a/bsubScripts/ncum_global_post/ncum_global_post_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_post/ncum_global_post_um2grb2_setup.cfg
@@ -93,16 +93,24 @@ overwriteFiles = True
 ## single digit hour, it will fill 0 as prefix to make it as 2 digit.
 ## same option for utc '*Z*'.
 ## Note : * will not be included in the name of the final out grib2 files.
-## for eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
+## eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
 ## this will produce analysis files as 'um_ana_006hr_20160208_12Z.grib2'
-## for eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
+## eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
 ## produce forecast files as 'fcs_06h_z20160208.grb2'
+## as 'prg100z080216.grb2'  
+## eg3 : ('prg', '*D*', '00z', '*%d%m%y*', '.grb2') will produce grib2 files 
+## as 'prg100z080216.grb2'
+## eg4 : ('prg', '*D*', '00z', '*%d%m%y*', '_', '*pxp*' '.grb2') will produce grib2 files 
+## as 'prg100z080216_0p17x0p17.grb2' in case of targetGridResolution = None (i.e modelResolution)  
+## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
-anlOutGrib2FilesNameStructure = ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+anlOutGrib2FilesNameStructure = ('um_ana', '_', '*HHH*', 'hr', '_',
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## Defining forecast grib2 fileName structure
-fcstOutGrib2FilesNameStructure = ('um_prg', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+fcstOutGrib2FilesNameStructure = ('um_prg', '_', '*HHH*', 'hr', '_', 
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## If createCtlIdxFiles is True then um2grb2 module will create grads control 
 ## files and its index files for each and every grib2 files by using g2ctl.pl 

--- a/bsubScripts/ncum_global_vsdb_input/ncum_global_vsdb_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_vsdb_input/ncum_global_vsdb_input_um2grb2_setup.cfg
@@ -111,6 +111,9 @@ overwriteFiles = True
 ## produce grib2 files as 'fcs_06h_z20160208.grb2'
 ## eg3 : ('prg', '*D*', '00z', '*%d%m%y*', '.grb2') will produce grib2 files 
 ## as 'prg100z080216.grb2' 
+## eg4 : ('prg', '*D*', '00z', '*%d%m%y*', '_', '*pxp*' '.grb2') will produce grib2 files 
+## as 'prg100z080216_0p17x0p17.grb2' in case of targetGridResolution = None (i.e modelResolution)  
+## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
 anlOutGrib2FilesNameStructure = ('prg', '*H*', '00z', '*%d%m%y*', '.grb2')

--- a/bsubScripts/ncum_india_reg_from_global/ncum_india_reg_from_global_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_india_reg_from_global/ncum_india_reg_from_global_um2grb2_setup.cfg
@@ -93,16 +93,23 @@ overwriteFiles = True
 ## single digit hour, it will fill 0 as prefix to make it as 2 digit.
 ## same option for utc '*Z*'.
 ## Note : * will not be included in the name of the final out grib2 files.
-## for eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
+## eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
 ## this will produce analysis files as 'um_ana_006hr_20160208_12Z.grib2'
-## for eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
+## eg2 : ('fcs', '_', '*HH*', 'h', '_z', '*YYYYMMDD*', '.grb2') this will 
 ## produce forecast files as 'fcs_06h_z20160208.grb2'
+## eg3 : ('prg', '*D*', '00z', '*%d%m%y*', '.grb2') will produce grib2 files 
+## as 'prg100z080216.grb2'  
+## eg4 : ('prg', '*D*', '00z', '*%d%m%y*', '_', '*pxp*' '.grb2') will produce grib2 files 
+## as 'prg100z080216_0p17x0p17.grb2' in case of targetGridResolution = None (i.e modelResolution)  
+## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
-anlOutGrib2FilesNameStructure = ('NCUM_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+anlOutGrib2FilesNameStructure = ('NCUM_ana', '_', '*HHH*', 'hr', '_', 
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## Defining forecast grib2 fileName structure
-fcstOutGrib2FilesNameStructure = ('NCUM_fcs', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+fcstOutGrib2FilesNameStructure = ('NCUM_fcs', '_', '*HHH*', 'hr', '_', 
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## If createCtlIdxFiles is True then um2grb2 module will create grads control 
 ## files and its index files for each and every grib2 files by using g2ctl.pl 

--- a/g2scripts/um2grb2_setup.cfg
+++ b/g2scripts/um2grb2_setup.cfg
@@ -102,6 +102,7 @@ overwriteFiles = True
 ## hours have 3 digit, then by default it will assume as 3 digits but for 
 ## single digit hour, it will fill 0 as prefix to make it as 2 digit.
 ## same option for utc '*Z*'.
+## '*pXp*' - latitude x longitude grid resolution
 ## Note : * will not be included in the name of the final out grib2 files.
 ## eg1 :  ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')  
 ## this will produce grib2 files as 'um_ana_006hr_20160208_12Z.grib2'
@@ -109,6 +110,9 @@ overwriteFiles = True
 ## produce grib2 files as 'fcs_06h_z20160208.grb2'
 ## eg3 : ('prg', '*D*', '00z', '*%d%m%y*', '.grb2') will produce grib2 files 
 ## as 'prg100z080216.grb2'  
+## eg4 : ('prg', '*D*', '00z', '*%d%m%y*', '_', '*pxp*' '.grb2') will produce grib2 files 
+## as 'prg100z080216_0p17x0p17.grb2' in case of targetGridResolution = None (i.e modelResolution)  
+## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
 anlOutGrib2FilesNameStructure = ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')

--- a/g2scripts/um2grb2_setup.cfg
+++ b/g2scripts/um2grb2_setup.cfg
@@ -115,10 +115,12 @@ overwriteFiles = True
 ## or as 'prg100z080216_2p5x2p5.grb2' in case of targetGridResolution = 2.5
 
 ## Defining analysis grib2 fileName structure
-anlOutGrib2FilesNameStructure = ('um_ana', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+anlOutGrib2FilesNameStructure = ('um_ana', '_', '*HHH*', 'hr', '_',
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## Defining forecast grib2 fileName structure
-fcstOutGrib2FilesNameStructure = ('um_prg', '_', '*HHH*', 'hr', '_', '*YYYYMMDD*', '_', '*ZZ*', 'Z', '.grib2')
+fcstOutGrib2FilesNameStructure = ('um_prg', '_', '*HHH*', 'hr', '_', 
+                 '*YYYYMMDD*', '_', '*ZZ*', 'Z', '_', '*pxp*', '.grib2')
 
 ## If createCtlIdxFiles is True then um2grb2 module will create grads control 
 ## files and its index files for each and every grib2 files by using g2ctl.pl 

--- a/g2utils/um2grb2.py
+++ b/g2utils/um2grb2.py
@@ -422,6 +422,10 @@ def __getAnlFcstFileNameIdecies__(fileNameStructure):
     # get the utcIdx of utc pattern
     utcIdx = [idx[0] for idx in findInList(fileNameStructure, 
                             ['*Z*', '*ZZ*', '*ZZZ*']) if idx]
+                            
+    # get the resolution pattern
+    pIdx = [idx[0] for idx in findInList(fileNameStructure, 
+                                            ['*pXp*']) if idx]
     if hourIdx:
         hourIdx = hourIdx[0]        
         hr = fileNameStructure[hourIdx]
@@ -438,16 +442,20 @@ def __getAnlFcstFileNameIdecies__(fileNameStructure):
         day = fileNameStructure[dayIdx]
         dayFill = len(day.split('*')[1])
     
+    if pIdx: pIdx = pIdx[0]
+            
     return [(dateIdx, dateFormat), (hourIdx, hrFill), 
-                (utcIdx, utcFill), (dayIdx, dayFill)]
+                (utcIdx, utcFill), (dayIdx, dayFill), (pIdx, None)]
 # end of def _genAnlFcstFileName(fileNameStructure):
 
 
 def __genAnlFcstOutFileName__(fileNameStructure, indecies, fcstDate, fcstHour, 
-                                                    fcstUTC, preExtension=''):
+                             fcstUTC, preExtension='', modelResolution='0.17'):
+    
+    global _targetGridRes_
     
     # get the indecies 
-    (dateIdx, dateFormat), (hourIdx, hrFill), (utcIdx, utcFill), (dayIdx, dayFill) = indecies
+    (dateIdx, dateFormat), (hourIdx, hrFill), (utcIdx, utcFill), (dayIdx, dayFill), (pIdx, _) = indecies
     # copy the argument list into local list, so that it wont change the arg.
     fileNameStructure = list(fileNameStructure) # copy of the original
 
@@ -473,6 +481,14 @@ def __genAnlFcstOutFileName__(fileNameStructure, indecies, fcstDate, fcstHour,
     # update the utc 
     if utcIdx and utcFill:
         fileNameStructure[utcIdx] = str(int(fcstUTC)).zfill(utcFill)
+    
+    # update resolution
+    if pIdx:
+        res = _targetGridRes_ if _targetGridRes_ else modelResolution
+        if not '.' in res: res = str(float(res))
+        res = res.replace('.', 'p')
+        fileNameStructure[pIdx] = res + 'X' + res
+        
     # insert pre-extension string
     fileNameStructure.insert(-1, preExtension)
     


### PR DESCRIPTION
Included '_pXp_' option in file name structure to include target grid resolution in filename itself. Fixed #24 
