### PR TITLE
support for UMRIDER_STARTDATE & UMRIDER_ENDDATE environmental vars

### DIFF
--- a/bsubScripts/ncum_global_hycom_input/ncum_global_hycom_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_hycom_input/ncum_global_hycom_input_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 
@@ -39,7 +41,7 @@ enddate = None
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs3/home/umfcst/NCUM/ShortJobs/HycomInput/
+outPath = /gpfs3/home/umfcst/ShortJobs/Hycom/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs3/home/umfcst/UMRiderLogs/hycom/

--- a/bsubScripts/ncum_global_imd_mfi_input/imd_mfi_rename_g2files_and_put_into_ftp.py
+++ b/bsubScripts/ncum_global_imd_mfi_input/imd_mfi_rename_g2files_and_put_into_ftp.py
@@ -48,12 +48,21 @@ def renameFiles(outpath):
         subprocess.call(cmd, shell=True)
         os.remove(gf)
         print "created IMD MFI standard grib2 file from %s to %s" % (gf, mfi_g2out_name)
+        # do scp the grb2 files to ftp_server and nkn_server        
+        cmd = 'rsh ncmr0102 "scp -p %s  %s:NCUM_MFI/DATA/"' % (mfi_g2out_name, nkn_server)
+        subprocess.call(cmd, shell=True)
     # end of for gf in gfiles:
     os.chdir(cdir)
+    
+    cmd = 'rsh ncmr0102 "scp -r %s  %s:NCUM_MFI/DATA/"' % (outpath, ftp_server)
+    subprocess.call(cmd, shell=True)
+    
 # end of def renameFiles(outpath):
 
 if __name__ == '__main__':
-
+    
+    nkn_server="imd@nkn"
+    ftp_server="prod@ftp"
     date = None
     outpath = None
     oftype = None

--- a/bsubScripts/ncum_global_imd_mfi_input/ncum_global_imd_mfi_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_imd_mfi_input/ncum_global_imd_mfi_input_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 
@@ -39,7 +41,7 @@ enddate = None
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs3/home/umfcst/NCUM/ShortJobs/IMD_MFI_Input/
+outPath = /gpfs3/home/umfcst/ShortJobs/IMD-MFI/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs3/home/umfcst/UMRiderLogs/mfi/

--- a/bsubScripts/ncum_global_osf_input/ncum_global_osf_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_osf_input/ncum_global_osf_input_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 
@@ -39,7 +41,7 @@ enddate = None
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs3/home/umfcst/NCUM/ShortJobs/OsfInput/
+outPath = /gpfs3/home/umfcst/ShortJobs/OSF.NEW/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs3/home/umfcst/UMRiderLogs/osf/

--- a/bsubScripts/ncum_global_post/ncum_global_post_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_post/ncum_global_post_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 

--- a/bsubScripts/ncum_global_vsdb_input/ncum_global_vsdb_input_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_global_vsdb_input/ncum_global_vsdb_input_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 
@@ -39,7 +41,7 @@ enddate = None
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs3/home/umfcst/NCUM/ShortJobs/VsdbInput/
+outPath = /gpfs3/home/umfcst/ShortJobs/VSDB_Input/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs3/home/umfcst/UMRiderLogs/vsdb/

--- a/bsubScripts/ncum_india_reg_from_global/ncum_india_reg_from_global_um2grb2_setup.cfg
+++ b/bsubScripts/ncum_india_reg_from_global/ncum_india_reg_from_global_um2grb2_setup.cfg
@@ -15,6 +15,7 @@
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 
 startdate = YYYYMMDD
 
@@ -26,6 +27,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 
 enddate = None
 
@@ -39,7 +41,7 @@ enddate = None
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs3/home/umfcst/NCUM/ShortJobs/IndReg/
+outPath = /gpfs3/home/umfcst/ShortJobs/IndRegion/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs3/home/umfcst/UMRiderLogs/indreg/

--- a/g2scripts/loadconfigure.py
+++ b/g2scripts/loadconfigure.py
@@ -124,6 +124,9 @@ if callBackScript is not None:
         raise ValueError("In configure file, callBackScript = %s' path does not exists" % callBackScript)
 # end of if callBackScript is not None:
 
+# get the environment variable startdate and enddate, if not then get it from setup config file.
+startdate = os.environ.get('UMRIDER_STARTDATE', startdate).strip()
+enddate = os.environ.get('UMRIDER_ENDDATE', enddate).strip()
 # get the current date if not specified
 if startdate == 'YYYYMMDD': startdate = time.strftime('%Y%m%d')
 if enddate == 'YYYYMMDD': enddate = time.strftime('%Y%m%d')

--- a/g2scripts/um2grb2_setup.cfg
+++ b/g2scripts/um2grb2_setup.cfg
@@ -77,6 +77,7 @@ pressureLevels = None
 ## But user can specify the different startdate by follwing the same format.
 ## for eg, startdate = 20151209 # then it will execute the scripts for 09-Dec-2015.
 ## startdate = YYYYMMDD # then it will execute the scripts for today's date.
+## Note : However UMRIDER_STARTDATE environment variable will override this startdate option.
 startdate = YYYYMMDD
 
 ## By default enddate is None. User can specify different enddate (but > startdate)
@@ -87,6 +88,7 @@ startdate = YYYYMMDD
 ## startdate is lower than enddate.
 ## For eg : startdate = 20151209 and enddate = 20160114 , then um2grb2
 ## conversion program executes from 09-dec-2015 to 14-jan-2016.
+## Note : However UMRIDER_ENDDATE environment variable will override this enddate option.
 enddate = None
 
 ## Load g2utils from 'system' python which has installed through setup.py (OR)


### PR DESCRIPTION
Now it looks for UMRIDER_STARTDATE & UMRIDER_ENDDATE environmental vars. If it is not there, then it will take date 'startdate', 'enddate' vars from setup.cfg file.

Closes   #63 
